### PR TITLE
Remove Permissions from Pronto

### DIFF
--- a/workflow-templates/gnar-pronto.yml
+++ b/workflow-templates/gnar-pronto.yml
@@ -7,9 +7,6 @@ on:
 jobs:
   pronto:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      statuses: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This was causing an error now that github actions are better at regulating themselves. Removing the permissions line makes it all work. 